### PR TITLE
Support Python 3.10

### DIFF
--- a/kafka_connect/__init__.py
+++ b/kafka_connect/__init__.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 import json

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='kafka-connect-python',
-      version='0.0.3',
+      version='0.0.4',
       description='Kafka Connect Module',
       url='http://github.com/sxnxl/kafka-connect-python',
       author='Senol Korkmaz',


### PR DESCRIPTION
Import `MutableMapping` from `collections.abc` because it's no longer available in Python 3.10

Documentation https://docs.python.org/3.9/library/collections.html